### PR TITLE
Increase CMake minimum version (needed for building famfs on a system with latest CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -ggdb")
 

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 

--- a/testlib/CMakeLists.txt
+++ b/testlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(testlib)
 


### PR DESCRIPTION
When trying to build famfs (https://github.com/jagalactic/famfs) on an Arch linux system with a new CMake (cmake version 4.0.3-dirty), the build fails because building this repo has too old of a minimum CMake version. Bumping the minimum version here to v3.5 appears to make famfs build successfully (at least `make clean all; echo $?` prints 0...).

See the commit message for the exact error I got.

I am not that familiar with CMake so I don't have the experience to know whether it would be better to use the suggested `<min>...<max>` syntax to support a range of versions. If you feel that would be better, let me know. Or if you would prefer another way to resolve this build issue, let me know as well -- this is just the simplest thing that made famfs build successfully in my environment.

It does appear that CMake v3.5 is old enough by now that I expect most distributions someone would likely use today should provide a CMake newer than 3.5.